### PR TITLE
Add ClosetToggle functionality

### DIFF
--- a/Packages/kr.needon.modular-auto-closet/Editor/HierarchyGUI.cs
+++ b/Packages/kr.needon.modular-auto-closet/Editor/HierarchyGUI.cs
@@ -38,7 +38,7 @@ namespace needon.Editor
 
         private static bool HasClosetComponents(GameObject gameObject)
         {
-            return gameObject.GetComponent<AutoCloset>();
+            return gameObject.GetComponent<AutoCloset>() || gameObject.GetComponent<ClosetToggle>();
         }
 
         private static void DrawIcons(Component[] components, Rect iconRect)
@@ -51,7 +51,7 @@ namespace needon.Editor
                 }
 
                 var componentType = component.GetType();
-                if (componentType != typeof(AutoCloset)) continue;
+                if (componentType != typeof(AutoCloset) && componentType != typeof(ClosetToggle)) continue;
                 var icon = AssetPreview.GetMiniThumbnail(component);
                 if (icon == null) continue;
                 GUI.DrawTexture(iconRect, icon);

--- a/Packages/kr.needon.modular-auto-closet/Editor/Pass/AutoClosetUtil.cs
+++ b/Packages/kr.needon.modular-auto-closet/Editor/Pass/AutoClosetUtil.cs
@@ -114,7 +114,7 @@ namespace needon.Editor.Pass
             foreach (Transform child in closet.transform)
             {
                 var isActive = (child.name == activeClothesName);
-                
+
                 // 단일 키프레임만 사용하여 0초 시점에만 값을 기록
                 var curve = new AnimationCurve(
                     new Keyframe(0f, isActive ? 1f : 0f)
@@ -123,14 +123,39 @@ namespace needon.Editor.Pass
                 // 아바타 루트로부터의 상대 경로 계산
                 var relativePath = GetRelativePath(child.transform, avatarRoot);
                 Debug.Log($"Setting animation path: {relativePath} (Active: {isActive})");
-                
+
                 var binding = EditorCurveBinding.FloatCurve(
                     relativePath,
                     typeof(GameObject),
                     "m_IsActive"
                 );
-                
+
                 AnimationUtility.SetEditorCurve(clip, binding, curve);
+
+                // 추가 ClosetToggle 컴포넌트 처리
+                var closetToggle = child.GetComponent<ClosetToggle>();
+                if (closetToggle != null && closetToggle.toggles != null)
+                {
+                    foreach (var toggle in closetToggle.toggles)
+                    {
+                        if (toggle == null || toggle.target == null) continue;
+
+                        var toggleCurve = new AnimationCurve(
+                            new Keyframe(0f, isActive ? (toggle.active ? 1f : 0f) : (toggle.active ? 0f : 1f))
+                        );
+
+                        var togglePath = GetRelativePath(toggle.target.transform, avatarRoot);
+                        Debug.Log($"Toggle path: {togglePath} (Active: {isActive})");
+
+                        var toggleBinding = EditorCurveBinding.FloatCurve(
+                            togglePath,
+                            typeof(GameObject),
+                            "m_IsActive"
+                        );
+
+                        AnimationUtility.SetEditorCurve(clip, toggleBinding, toggleCurve);
+                    }
+                }
             }
 
             // 애니메이션 저장

--- a/Packages/kr.needon.modular-auto-closet/Examples/ClosetToggleExample.cs
+++ b/Packages/kr.needon.modular-auto-closet/Examples/ClosetToggleExample.cs
@@ -1,0 +1,33 @@
+using UnityEngine;
+
+public class ClosetToggleExample : MonoBehaviour
+{
+    public GameObject[] clothes; // clothing items to toggle with numeric keys
+    private int activeIndex = 0;
+    void Start()
+    {
+        ActivateClothes(activeIndex);
+    }
+
+    void Update()
+    {
+        for (int i = 0; i < clothes.Length; i++)
+        {
+            if (Input.GetKeyDown((i + 1).ToString()))
+            {
+                ActivateClothes(i);
+            }
+        }
+    }
+
+    private void ActivateClothes(int index)
+    {
+        for (int i = 0; i < clothes.Length; i++)
+        {
+            if (clothes[i] != null)
+            {
+                clothes[i].SetActive(i == index);
+            }
+        }
+    }
+}

--- a/Packages/kr.needon.modular-auto-closet/Examples/ClosetToggleExample.cs.meta
+++ b/Packages/kr.needon.modular-auto-closet/Examples/ClosetToggleExample.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bcb5b0b3b7234d9285cb5ce9fbd43097
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/kr.needon.modular-auto-closet/Runtime/ClosetToggle.cs
+++ b/Packages/kr.needon.modular-auto-closet/Runtime/ClosetToggle.cs
@@ -1,0 +1,14 @@
+using System;
+using UnityEngine;
+
+[Serializable]
+public class ClosetToggleItem
+{
+    public GameObject target;
+    public bool active = true;
+}
+
+public class ClosetToggle : MonoBehaviour
+{
+    public ClosetToggleItem[] toggles;
+}

--- a/Packages/kr.needon.modular-auto-closet/Runtime/ClosetToggle.cs.meta
+++ b/Packages/kr.needon.modular-auto-closet/Runtime/ClosetToggle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f1ee7a8bbdf04d4c9325854ecbc0a159
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add ClosetToggle component to define extra objects to toggle
- extend AutoClosetUtil to animate ClosetToggle targets
- update HierarchyGUI to show icons for ClosetToggle
- provide example script demonstrating toggling behavior

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_685333f3425c83238d1f8231eb3d4588