### PR TITLE
Add configurable toggle root name

### DIFF
--- a/Packages/kr.needon.modular-auto-closet/Editor/AutoClosetEditor.cs
+++ b/Packages/kr.needon.modular-auto-closet/Editor/AutoClosetEditor.cs
@@ -96,6 +96,8 @@ namespace needon.Editor
                 return;
             }
 
+            EditorGUILayout.PropertyField(_autoCloset.FindProperty("toggleRootName"), new GUIContent("Toggle Root Name"));
+
             _autoCloset.ApplyModifiedProperties();
 
             GUILayout.FlexibleSpace();

--- a/Packages/kr.needon.modular-auto-closet/Editor/ToggleCreator.cs
+++ b/Packages/kr.needon.modular-auto-closet/Editor/ToggleCreator.cs
@@ -28,11 +28,16 @@ namespace needon.Editor
             if (closetRoot == null)
                 throw new Exception("AutoCloset 컴포넌트가 붙어있는 옷장 루트를 찾을 수 없습니다.");
 
-            // Toggle 루트 생성/조회
-            var toggleRootObj = closetRoot.Find("Toggle")?.gameObject;
+            // Toggle 루트 생성/조회 (AutoCloset 설정 사용)
+            var closetComponent = closetRoot.GetComponent<AutoCloset>();
+            var rootName = closetComponent != null && !string.IsNullOrEmpty(closetComponent.toggleRootName)
+                ? closetComponent.toggleRootName
+                : "Toggle";
+
+            var toggleRootObj = closetRoot.Find(rootName)?.gameObject;
             if (toggleRootObj == null)
             {
-                toggleRootObj = new GameObject("Toggle");
+                toggleRootObj = new GameObject(rootName);
                 toggleRootObj.transform.SetParent(closetRoot, false);
             }
 

--- a/Packages/kr.needon.modular-auto-closet/Runtime/AutoCloset.cs
+++ b/Packages/kr.needon.modular-auto-closet/Runtime/AutoCloset.cs
@@ -7,6 +7,12 @@ public class AutoCloset : AvatarTagComponent
 
 {
     private static Texture2D _icon;
+
+    /// <summary>
+    /// Name of the toggle root object created by the ToggleCreator.
+    /// </summary>
+    public string toggleRootName = "Toggle";
+
     public IEnumerable Clothes;
 }
 #endif

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@
 
 https://github.com/user-attachments/assets/3a674f0f-50e2-43c8-8594-24d8f0610ba1
 
+### Custom Toggle Root Name
+The **AutoCloset** component now exposes a **Toggle Root Name** field. When
+creating toggles, the tool will create or find a child object with this name
+instead of the default `Toggle`.
+
 ## References
 1. [https://github.com/bdunderscore/modular-avatar](https://github.com/bdunderscore/modular-avatar)
 2. [https://github.com/bdunderscore/ndmf](https://github.com/bdunderscore/ndmf)


### PR DESCRIPTION
## Summary
- expose a `toggleRootName` field on `AutoCloset`
- use the value when creating toggle groups
- show the field in `AutoClosetEditor`
- document the new option in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_68559ff703148323941ec3ab87ab99ed