### PR TITLE
fix: 묵시 파라미터 Bool(1bit) 전환 + 안 입은 의상 PhysBone 보존 제외

### DIFF
--- a/Packages/kr.needon.modular-auto-closet/Editor/Pass/ApplyAutoClosetPass.cs
+++ b/Packages/kr.needon.modular-auto-closet/Editor/Pass/ApplyAutoClosetPass.cs
@@ -39,6 +39,11 @@ namespace needon.Editor.Pass
 
                 // 아바타에 부착된 모든 AutoCloset 컴포넌트를 가져옴 (비활성 포함)
                 var closetComponents = avatar.GetComponentsInChildren<AutoCloset>(true);
+
+                // 원래 비활성(안 입은 상태로 저장된) 보존 의상 — 모든 옷장의 클립 생성이
+                // 끝난 뒤 렌더러를 직렬화 수준에서 꺼서 rest 상태 겹침을 방지한다
+                var originallyInactiveDynamics = new HashSet<Transform>();
+
                 foreach (var closetComponent in closetComponents)
                 {
                     var closetGameObject = closetComponent.gameObject;
@@ -60,6 +65,12 @@ namespace needon.Editor.Pass
                     // 보존 대상 PhysBone(= enabled이고 의상 루트까지 체인이 켜져 있는 것)을
                     // 가진 의상 목록을 1회 계산해 활성화/옵티마이저 제외/클립 생성이 공유
                     var dynamicsChildren = CollectDynamicsChildren(closetGameObject);
+                    foreach (var child in dynamicsChildren)
+                    {
+                        if (!child.gameObject.activeSelf)
+                            originallyInactiveDynamics.Add(child);
+                    }
+
                     ActivateDynamicHierarchies(closetGameObject, dynamicsChildren);
                     ExcludeDynamicPhysBonesFromTraceAndOptimize(context.AvatarRootObject, dynamicsChildren);
 
@@ -74,6 +85,8 @@ namespace needon.Editor.Pass
                     var writeDefaults = AutoClosetUtil.ResolveWriteDefaults(context, closetGameObject);
                     CreateClosetStates(closetGameObject, stateMachine, uniqueName, context, layerIndex, writeDefaults, avatarParameterDefaults, dynamicsChildren);
                 }
+
+                DisableInactiveDynamicsRenderers(originallyInactiveDynamics);
             }
             catch (Exception e)
             {
@@ -768,6 +781,32 @@ namespace needon.Editor.Pass
                 }
 
                 current = current.parent;
+            }
+        }
+
+        /// <summary>
+        /// 원래 비활성이던(안 입은 상태로 저장된) 보존 의상의 렌더러를 직렬화 수준에서 끕니다.
+        /// GameObject는 활성(m_IsActive=1)으로 유지되어 PhysBone은 계속 시뮬레이션되지만,
+        /// 애니메이터가 돌기 전 rest 상태(업로드 썸네일 캡처, 재생 직후 T포즈)에서는 보이지 않습니다.
+        /// 클립이 모든 옷장 상태에서 렌더러 m_Enabled를 명시적으로 구동하므로 런타임 표시는 애니메이터가 복원합니다.
+        /// 주의: 클립 생성(AccumulateRendererCurves)이 에디터 시점의 renderer.enabled를 "입었을 때 값"으로
+        /// 읽으므로, 반드시 모든 옷장의 CreateClosetStates가 끝난 뒤에 호출해야 합니다(중첩 옷장 포함).
+        /// </summary>
+        private void DisableInactiveDynamicsRenderers(HashSet<Transform> originallyInactiveDynamics)
+        {
+            foreach (var child in originallyInactiveDynamics)
+            {
+                if (child == null)
+                    continue;
+
+                foreach (var renderer in child.GetComponentsInChildren<Renderer>(true))
+                {
+                    if (renderer == null || !renderer.enabled)
+                        continue;
+
+                    renderer.enabled = false;
+                    EditorUtility.SetDirty(renderer);
+                }
             }
         }
 

--- a/Packages/kr.needon.modular-auto-closet/Editor/Pass/ApplyAutoClosetPass.cs
+++ b/Packages/kr.needon.modular-auto-closet/Editor/Pass/ApplyAutoClosetPass.cs
@@ -432,8 +432,8 @@ namespace needon.Editor.Pass
                     parametersToAdd.Add(new AnimatorControllerParameter
                     {
                         name = info.ParameterName,
-                        type = AnimatorControllerParameterType.Float,
-                        defaultFloat = info.DefaultValue
+                        type = AnimatorControllerParameterType.Bool,
+                        defaultBool = !Mathf.Approximately(info.DefaultValue, 0f)
                     });
                     continue;
                 }
@@ -491,6 +491,13 @@ namespace needon.Editor.Pass
                 {
                     name = CreateStableMenuParameterName(closet, menuItem, uniqueName)
                 };
+
+                // 묵시 파라미터를 명시적 Bool 토글로 고정한다. automaticValue를 켜두면
+                // Modular Avatar가 파라미터를 Float(8bit)로 확장하므로, 명시 값(1)으로
+                // 전환해 Bool(1bit)로 생성되게 한다 (동기화 예산 토글당 8→1bit 절감).
+                menuItem.automaticValue = false;
+                control.value = 1f;
+
                 EnsureMenuParameterConfig(menuItem, control);
                 EditorUtility.SetDirty(menuItem);
             }
@@ -520,10 +527,10 @@ namespace needon.Editor.Pass
             parameters.parameters.Add(new ParameterConfig
             {
                 nameOrPrefix = parameterName,
-                // AutoCloset reset drivers reference these parameters before Modular Avatar
-                // finalizes menu parameters, so MA expands them to Float in the FX controller.
-                // Declaring them as Float keeps Expression Parameters, drivers, and conditions aligned.
-                syncType = ParameterSyncType.Float,
+                // NormalizeImplicitMenuParameters에서 automaticValue=false + value=1로 고정하므로
+                // Modular Avatar가 이 파라미터를 Bool(1bit)로 생성한다. Expression Parameters /
+                // 드라이버 / 애니메이터 파라미터를 모두 Bool로 맞춰 동기화 예산을 토글당 8→1bit로 줄인다.
+                syncType = ParameterSyncType.Bool,
                 // MA가 빈 파라미터를 자동 할당할 때와 동일하게 메뉴 아이템의 동기화 설정을 따른다.
                 // (localOnly 강제 시 원격 플레이어에게 기믹 상태가 보이지 않음)
                 localOnly = !menuItem.isSynced,

--- a/Packages/kr.needon.modular-auto-closet/Editor/Pass/AutoClosetUtil.cs
+++ b/Packages/kr.needon.modular-auto-closet/Editor/Pass/AutoClosetUtil.cs
@@ -585,9 +585,10 @@ namespace needon.Editor.Pass
 
         /// <summary>
         /// 의상이 "보존 대상" PhysBone을 갖는지 판정합니다.
-        /// 보존 대상 = enabled이고, 의상 루트(자신 포함)까지의 GameObject 체인이 모두 activeSelf인 PhysBone.
-        /// 즉 지금 실제로 입고 있는(활성) 의상만 보존 대상이며, 안 입은 의상이나 유저가 의도적으로
-        /// 꺼둔 서브트리의 PhysBone은 보존하지 않습니다(rest 상태 겹침 방지 + 바닐라 동작 유지).
+        /// 보존 대상 = enabled이고, 의상 루트까지의 GameObject 체인이 모두 activeSelf인 PhysBone.
+        /// 유저가 의도적으로 꺼둔 서브트리의 PhysBone은 보존하지 않습니다(바닐라 동작 유지).
+        /// 안 입은 의상(루트 activeSelf=false)도 보존 대상 — rest 상태 겹침은
+        /// ApplyAutoClosetPass가 렌더러를 직렬화 수준에서 꺼서 방지합니다.
         /// </summary>
         internal static bool HasPreservablePhysBones(Transform closetChild)
         {
@@ -623,15 +624,7 @@ namespace needon.Editor.Pass
             if (physBone == null || !physBone.enabled)
                 return false;
 
-            // 지금 입고 있지 않은 의상(루트 activeSelf=false)은 보존 대상에서 제외한다.
-            // 안 입은 옷까지 m_IsActive=1로 상시 켜두면, 애니메이터가 적용되기 전 상태
-            // (업로드 썸네일 캡처 / 재생 직후 T포즈 등 rest 상태)에서 모든 의상이 동시에
-            // 보여 겹친다. 보존은 실제 착용(=활성) 중인 의상의 PhysBone 연속성만 지키면 충분하다.
-            if (!closetChild.gameObject.activeSelf)
-                return false;
-
-            // 의상 루트까지의 GameObject 체인이 모두 activeSelf인지 검사한다.
-            // (유저가 의도적으로 꺼둔 서브트리의 PhysBone은 보존하지 않음 — 바닐라 동작 유지)
+            // 의상 루트(closetChild) 자신의 activeSelf는 옷장이 관리하므로 검사하지 않는다.
             var current = physBone.transform;
             while (current != null && current != closetChild)
             {

--- a/Packages/kr.needon.modular-auto-closet/Editor/Pass/AutoClosetUtil.cs
+++ b/Packages/kr.needon.modular-auto-closet/Editor/Pass/AutoClosetUtil.cs
@@ -585,8 +585,9 @@ namespace needon.Editor.Pass
 
         /// <summary>
         /// 의상이 "보존 대상" PhysBone을 갖는지 판정합니다.
-        /// 보존 대상 = enabled이고, 의상 루트까지의 GameObject 체인이 모두 activeSelf인 PhysBone.
-        /// 유저가 의도적으로 꺼둔 서브트리의 PhysBone은 보존하지 않습니다(바닐라 동작 유지).
+        /// 보존 대상 = enabled이고, 의상 루트(자신 포함)까지의 GameObject 체인이 모두 activeSelf인 PhysBone.
+        /// 즉 지금 실제로 입고 있는(활성) 의상만 보존 대상이며, 안 입은 의상이나 유저가 의도적으로
+        /// 꺼둔 서브트리의 PhysBone은 보존하지 않습니다(rest 상태 겹침 방지 + 바닐라 동작 유지).
         /// </summary>
         internal static bool HasPreservablePhysBones(Transform closetChild)
         {
@@ -622,7 +623,15 @@ namespace needon.Editor.Pass
             if (physBone == null || !physBone.enabled)
                 return false;
 
-            // 의상 루트(closetChild) 자신의 activeSelf는 옷장이 관리하므로 검사하지 않는다.
+            // 지금 입고 있지 않은 의상(루트 activeSelf=false)은 보존 대상에서 제외한다.
+            // 안 입은 옷까지 m_IsActive=1로 상시 켜두면, 애니메이터가 적용되기 전 상태
+            // (업로드 썸네일 캡처 / 재생 직후 T포즈 등 rest 상태)에서 모든 의상이 동시에
+            // 보여 겹친다. 보존은 실제 착용(=활성) 중인 의상의 PhysBone 연속성만 지키면 충분하다.
+            if (!closetChild.gameObject.activeSelf)
+                return false;
+
+            // 의상 루트까지의 GameObject 체인이 모두 activeSelf인지 검사한다.
+            // (유저가 의도적으로 꺼둔 서브트리의 PhysBone은 보존하지 않음 — 바닐라 동작 유지)
             var current = physBone.transform;
             while (current != null && current != closetChild)
             {

--- a/Packages/kr.needon.modular-auto-closet/package.json
+++ b/Packages/kr.needon.modular-auto-closet/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kr.needon.modular-auto-closet",
   "displayName": "Modular Auto Closet Tool",
-  "version": "1.0.9-beta.1",
+  "version": "1.0.9-beta.2",
   "unity": "2022.3",
   "vrchatVersion": "2022.1.1",
   "author": {


### PR DESCRIPTION
## 개요

MAYO_Kaihen 커미션 아바타 디버깅(2026-06-13)에서 발견·검증한 v1.0.9 후속 수정 2건입니다.

1. **묵시 메뉴 파라미터 Float(8bit) → Bool(1bit) 전환** — 동기화 예산이 빠듯한 아바타에서 옷장 토글이 조용히 원격 동기화되지 않는 문제 해결
2. **안 입은 의상의 PhysBone 보존 제외** — 업로드 썸네일/T포즈 등 rest 상태에서 모든 의상이 겹쳐 보이는 문제 해결

---

## 1. 묵시 파라미터 Bool 전환 (`ApplyAutoClosetPass.cs`)

### 증상
후드 토글(`Cat Hoodie Flip` / `Hoodie Off`)이 **본인 화면에선 동작하지만 다른 사람에게는 적용되지 않음**.

### 원인 체인
- 해당 아바타는 동기화 파라미터 자연수요가 256bit를 크게 초과 (FaceTracking만 ~150bit)
- **VRCFury가 실제 SDK 빌드(`OnPreprocessAvatar`)에서 예산을 256에 맞추려고 초과분 파라미터의 `networkSynced`를 끔** — 컷 기준은 bit 크기가 아니라 **우선순위/순서**라서, 컷 대상이 되면 1bit짜리여도 계속 잘림
- MAC의 묵시 파라미터는 `automaticValue=true` 상태라 **Modular Avatar가 FX에서 Float(8bit)로 확장** → 토글당 8bit 낭비가 예산 초과의 한 축이었음. 기존 Float 선언은 버그가 아니라 MA의 automaticValue 처리에 맞춘 정렬이었으므로, 근본 해결은 automaticValue를 끄고 명시 Bool로 가는 것

### 변경 (3곳을 모두 Bool로 정렬 — NDMF Harmonize 충돌 방지)
| 위치 | 변경 |
|---|---|
| `NormalizeImplicitMenuParameters` | `automaticValue=false` + `control.value=1` 고정 → MA가 Bool(1bit)로 생성 |
| `EnsureMenuParameterConfig` | `syncType = ParameterSyncType.Bool` (기존 Float) |
| `ApplyImplicitMenuParameterDefaultsToAnimator` | `_autoClosetController` 파라미터 `Bool`/`defaultBool` (기존 Float) |

### 왜 안전한가
- 일반 옷장 토글(`Toggle_*`)이 이미 쓰는 "automaticValue=false + 명시 Bool" 패턴 그대로
- `CollectMenuParameterResets` 리셋 휴리스틱 검토 완료 — 기본 OFF/ON 토글 모두 기존과 동일한 리셋값 유지
- 의상 전환 리셋은 `VRCAvatarParameterDriver(Set)` — Bool에 0/1 Set 정상 동작
- 적용 범위는 `ShouldAssignImplicitMenuParameter`가 허용하는 **Button/Toggle + 리액티브 컴포넌트 제어**뿐이라 라디얼/퍼펫(Float 필요)은 애초에 대상 아님

### ⚠️ 하위호환
기존 사용자 아바타가 재빌드되면 해당 묵시 파라미터가 Float→Bool로 바뀌어 **saved 값이 1회 리셋**됩니다(경미한 일회성 영향). 릴리스 changelog에 명시 권장.

---

## 2. rest 상태 의상 겹침 방지 (`ApplyAutoClosetPass.cs`, `AutoClosetUtil.cs`)

### 증상
PhysBone 보존 대상 의상은 빌드 시 GameObject가 활성화되고 모든 옷장 상태에서 `m_IsActive=1`을 유지하므로, 애니메이터가 적용되기 전 rest 상태(업로드 썸네일 캡처, 재생 직후 T포즈)에서 **모든 의상이 동시에 겹쳐 보임**.

### 접근 (리뷰 반영으로 변경됨)
- ~~최초 커밋(04e45df): 안 입은 의상(`activeSelf=false`)을 보존 대상에서 제외~~ → **리뷰 지적대로 기본 의상 외 모든 의상의 PhysBone 연속성이 사라지는 부작용** (갈아입는 순간 재초기화 — 보존 기능이 사실상 기본 의상 전용으로 축소)
- **최종(172d0fa): 모든 의상을 보존 대상으로 유지 + 원래 비활성이던 보존 의상의 렌더러를 클립 생성 완료 후 직렬화 수준에서 비활성화**
  - GameObject 활성 유지 → PhysBone 연속 시뮬레이션 보존
  - 렌더러 직렬화 OFF → rest 상태에서 안 보임 (겹침 해결)
  - 클립이 모든 옷장 상태에서 렌더러 `m_Enabled`를 명시적으로 구동하므로 런타임 표시는 애니메이터가 즉시 복원

### 순서 제약 (구현 주의점)
클립 생성(`AccumulateRendererCurves`)이 에디터 시점의 `renderer.enabled`를 "입었을 때 값"으로 읽으므로, 렌더러 끄기는 **전체 옷장 루프 종료 후 일괄 수행**. 옷장별 직후 처리 시 중첩 옷장에서 뒤 옷장의 클립이 앞 옷장이 꺼둔 값을 읽는 오염이 발생함.

---

## 검증

MAYO_Kaihen 실제 아바타에서 CoPlay `execute_script` 베이크로 검증:

**Bool 전환 (6/13):**
- 후드 토글 묵시 파라미터 `type=Bool, synced=True` 생성 확인, 빌드 에러 없음
- **컷 반영 측정 주의**: `ProcessAvatar`(NDMF만)로는 VRCFury 컷이 안 보임 — `VRCBuildPipelineCallbacks.OnPreprocessAvatar` 경로로 실제 업로드 결과 기준 측정

**리뷰 반영 후 rest 겹침 방지 (7/8, 10/10 PASS):**
- 안 입은 보존 의상 2벌(일상복·어흐어흐): 빌드 후 `m_IsActive=1` 유지(보존 ✓) + 렌더러 5개/20개 전부 직렬화 OFF(겹침 방지 ✓) + 착용 상태 클립이 `m_Enabled=1` 구동(표시 복원 ✓)
- 착용 중 보존 의상(스웨터): 렌더러 직렬화 값 원본 유지 — rest에서 정상 표시
- 비보존 의상(누드·Toggle): `activeSelf` 원본 유지 — 기존 동작 무변경
- 양쪽 Unity 프로젝트(dev·mayo) 컴파일 에러 없음

## 비고

- 버전 `1.0.9-beta.2`로 bump
- 상세 설계 노트는 로컬 `Documentation~/synced-param-budget-bool-toggle.md`에 보존 (Documentation~는 git 제외 컨벤션)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
